### PR TITLE
robot.get_block_type_at(location)

### DIFF
--- a/client/botchallenge/robot.py
+++ b/client/botchallenge/robot.py
@@ -184,6 +184,18 @@ class Robot(object):
         request.action_request.drop_amount = amount
         return self._action(request).success
 
+    def get_block_type_at(self, location):
+        """Find the type of the adjacent block in the given direction."""
+        request = self._new_action()
+        request.read_request.identify_material.absolute_location.x = location.x_coord
+        request.read_request.identify_material.absolute_location.y = location.y_coord
+        request.read_request.identify_material.absolute_location.z = location.z_coord
+        material_id = self._action(request).material_response.type
+        if material_id in BlockType.value_map:
+            return BlockType.value_map[material_id]
+        logging.warn("Unrecognized block type: %d", material_id)
+        return None
+
 
 
 class Location(object):

--- a/client/botchallenge/robot.py
+++ b/client/botchallenge/robot.py
@@ -185,7 +185,7 @@ class Robot(object):
         return self._action(request).success
 
     def get_block_type_at(self, location):
-        """Find the type of the adjacent block in the given direction."""
+        """Find the type of the block at the given location."""
         request = self._new_action()
         request.read_request.identify_material.absolute_location.x = location.x_coord
         request.read_request.identify_material.absolute_location.y = location.y_coord

--- a/client/setup.py
+++ b/client/setup.py
@@ -21,7 +21,7 @@ place blocks.
 
 setup(
     name="botchallenge",
-    version="1.3.2",
+    version="1.3.3",
     packages=find_packages(),
     install_requires=['greenlet'],
     author="Katie Bell",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>au.id.katharos</groupId>
   <artifactId>RoboMinionsPlugin</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.4-SNAPSHOT</version>
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/au/id/katharos/robominions/AbstractRobot.java
+++ b/src/main/java/au/id/katharos/robominions/AbstractRobot.java
@@ -143,9 +143,9 @@ public abstract class AbstractRobot implements InventoryHolder {
 			return false;
 		}
 		// Any block less than 10 blocks away is visible.
-		if (loc.distance(location.getBlock().getLocation()) > 10) {
-			return false;
-		}
+		// if (loc.distance(location.getBlock().getLocation()) > 10) {
+		//	 return false;
+		// }
 		return true;
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: RoboMinions
 main: au.id.katharos.robominions.RoboMinionsPlugin
-version: 0.3.0
+version: 0.4.0
 
 commands:
    spawnrobot:


### PR DESCRIPTION
Extends the botchallenge API to include robot.get_block_type_at(location) that uses the same bukkit code at robot.get_block_type(direction) but instead using a absolute coordinate in the Minecraft world.

I also made AbstractRobot.is_location_visible(location) on the backend always return True instead of limited to a 10 block distance to give us more freedom until something more logical for this function is added.
